### PR TITLE
chore(portainer): bump Portainer EE LTS to 2.33.7

### DIFF
--- a/services/portainer/compose.yaml
+++ b/services/portainer/compose.yaml
@@ -11,7 +11,7 @@ volumes:
 
 services:
   portainer:
-    image: portainer/portainer-ee:2.33.6
+    image: portainer/portainer-ee:2.33.7
     container_name: portainer
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary
- Update Portainer EE image from `2.33.6` to `2.33.7` in `services/portainer/compose.yaml`
- Keep on the 2.33.x LTS track while applying latest patch

## Why
Portainer release notes list a newer LTS patch (2.33.7) after 2.33.6.

## Risk / Rollback
- Risk: low (patch version bump only)
- Rollback: revert this commit or set image back to `portainer/portainer-ee:2.33.6`

Assisted-by: openai-codex/gpt-5.3-codex via OpenClaw
