### PR TITLE
ci(renovate): add minimal docker-compose update config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,7 @@
   "enabledManagers": ["docker-compose"],
   "docker-compose": {
     "fileMatch": [
-      "(^|/)services/.+/compose\\.ya?ml$",
-      "(^|/)apps/.+/compose\\.ya?ml$"
+      "(^|/)(services|apps)(/.+)?/compose\\.ya?ml$"
     ]
   },
   "labels": ["dependencies", "docker"],


### PR DESCRIPTION
## Summary
- Add Renovate config for Docker Compose updates in:
  - `services/**/compose.yaml`
  - `apps/**/compose.yaml`
- Fix `fileMatch` so top-level paths are included too.
- Enable digest pinning (`pinDigests`) for docker-compose images (hash-version workflow).
- Disable **major** auto-update proposals for core DB images (Postgres/Redis/Valkey/Immich Postgres).

## Notes
- Uses Renovate App model (no GitHub Action required).
- Conservative PR throttling remains in place.

## Rollback
- Revert/remove `renovate.json`.

Assisted-by: openai-codex/gpt-5.3-codex via OpenClaw
