### PR TITLE
ci(github): auto-request Copilot review on pull requests

### DIFF
--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -1,0 +1,41 @@
+name: Request Copilot review
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-copilot-review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request Copilot as reviewer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          api="https://api.github.com/repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers"
+          payload='{"reviewers":["copilot-pull-request-reviewer[bot]"]}'
+
+          status=$(curl -sS -o /tmp/resp.json -w "%{http_code}" \
+            -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${api}" \
+            -d "${payload}" || true)
+
+          if [ "${status}" = "200" ] || [ "${status}" = "201" ]; then
+            echo "Copilot reviewer requested for PR #${PR_NUMBER}."
+            exit 0
+          fi
+
+          echo "Non-fatal: could not request Copilot reviewer (HTTP ${status})."
+          cat /tmp/resp.json || true
+          exit 0


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow to request Copilot review on PR open/reopen/ready_for_review/synchronize.
- Uses `pull_request_target` with `pull-requests: write` permission.
- Request is non-fatal if Copilot review is unavailable.

## Why
Automate Copilot reviewer requests across PRs.

Assisted-by: openai-codex/gpt-5.3-codex via OpenClaw
