### PR TITLE
chore(deps): update nextcloud:33-apache docker digest to 5b7a52f

### DIFF
--- a/services/nextcloud/compose.yaml
+++ b/services/nextcloud/compose.yaml
@@ -6,7 +6,7 @@ networks:
 
 services:
   nextcloud:
-    image: nextcloud:33-apache@sha256:666fd3f31c0865991d75e73369e4c074d304b782c937112f7614cd7ddc5ae089
+    image: nextcloud:33-apache@sha256:5b7a52f
     container_name: nextcloud
     restart: unless-stopped
     networks:


### PR DESCRIPTION
This PR updates the nextcloud:33-apache docker image digest to the latest version.

### Changes
- Updated nextcloud:33-apache digest from `sha256:666fd3f31c0865991d75e73369e4c074d304b782c937112f7614cd7ddc5ae089` to `sha256:5b7a52f`

### Testing
- The change only updates the docker image digest
- No functional changes are expected
- Portainer will handle the image update via GitOps