### PR TITLE
fix(tailscale): enable IPv6 forwarding in container network namespace

### DIFF
--- a/services/tailscale-subnet-router/compose.yaml
+++ b/services/tailscale-subnet-router/compose.yaml
@@ -16,6 +16,8 @@ services:
     cap_add:
       - NET_ADMIN
       - NET_RAW
+    sysctls:
+      - net.ipv6.conf.all.forwarding=1
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Problem

The `tailscale-subnet-router` container shows:

- **IPv6 forwarding disabled** — blocks subnet routing and exit node functionality
- **Restart loop** — caused by invalid `TS_AUTHKEY` (separate issue, see below)

## Root cause

Docker containers have their own network namespace where `net.ipv6.conf.all.forwarding` defaults to `0`, even when the host has it enabled. Tailscale needs this to be `1` for subnet routing.

## Fix

Added `sysctls` to the compose:

```yaml
sysctls:
  - net.ipv6.conf.all.forwarding=1
```

## Host dependency

The container uses `TS_USERSPACE=false` (kernel WireGuard). The host must have the wireguard kernel module loaded. After a recent reboot it wasn't — run this on linux-mini to make it persistent:

```bash
echo "wireguard" | sudo tee /etc/modules-load.d/wireguard.conf
sudo modprobe wireguard
```

## Operator action required

The **auth key** is `${TS_AUTHKEY}` — pulled from the Portainer stack environment. The current value is invalid (`invalid key: API key does not exist` in logs). You need to:

1. Generate a new auth key in the Tailscale admin console (Settings → Keys → Generate auth key, with reusable + tags if desired)
2. Update the `TS_AUTHKEY` env variable in the Portainer stack
3. Redeploy the stack

After both fixes are applied, the container should come up clean with auth + subnet routing working.

## Rollback

Revert this commit — the sysctls change is additive and non-destructive. Removing it returns to previous behavior.