### PR TITLE
fix(home-assistant): avoid mDNS host port race

### DIFF
--- a/services/home-assistant/compose.yaml
+++ b/services/home-assistant/compose.yaml
@@ -30,8 +30,6 @@ services:
       - "8123:8123"
       # HomeKit bridge + accessory pairing ports (bridge mode)
       - "21063-21084:21063-21084"
-      # mDNS for HomeKit discovery when HA is not using host networking
-      - "5353:5353/udp"
     networks:
       - homeassistant
       - app_network


### PR DESCRIPTION
## Summary
- Remove Home Assistant's direct `5353:5353/udp` host publish.
- Leave `avahi-reflector` as the single host-network mDNS owner so Home Assistant can reattach external Docker networks after reboot.

## Test plan
- `yq '.' services/home-assistant/compose.yaml`
- Verified the live failure mode: Home Assistant was attached only to `ha_signal_private`, had no default route, and `docker network connect` failed on host UDP `5353` being in use.

## Why This Did Not Fail Before
This is a startup-order race. If Home Assistant binds host UDP `5353` first, the container can attach its external networks. After reboot, `avahi-reflector` can bind host `5353` first, and Docker then fails to complete Home Assistant's external network attachment, leaving it only on the internal `ha_signal_private` network with no default route.

Assisted-by: GPT-5.5 via Cursor

Made with [Cursor](https://cursor.com)