### PR TITLE
feat(openclaw): expose gateway on lan

### DIFF
--- a/services/openclaw/README.md
+++ b/services/openclaw/README.md
@@ -52,7 +52,8 @@ Note: these precedence rules apply once you provide an `openclaw.json` file insi
 
 ## Security Notes
 
-- `openclaw-gateway` is bound to loopback only: `127.0.0.1:${OPENCLAW_GATEWAY_PORT}`.
+- `openclaw-gateway` publishes `${OPENCLAW_GATEWAY_PORT:-18789}` on the Docker host so trusted LAN clients can reach it.
+- Gateway token auth stays enabled; do not expose this port outside the trusted LAN without a stronger ingress policy.
 - No Signal RPC host port is published. It is reachable only on Docker networks.
 - `cap_drop: [ALL]` and `no-new-privileges` are enabled for OpenClaw services.
 - Never commit real secrets in git.

--- a/services/openclaw/compose.yaml
+++ b/services/openclaw/compose.yaml
@@ -32,7 +32,7 @@ services:
       PORTAINER_API_KEY: ${PORTAINER_API_KEY}
       PORTAINER_URL: ${PORTAINER_URL}
     ports:
-      - "127.0.0.1:${OPENCLAW_GATEWAY_PORT:-18789}:18789"
+      - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
     volumes:
       - openclaw_state:/home/node/.openclaw
     networks:

--- a/services/openclaw/config/openclaw.template.json
+++ b/services/openclaw/config/openclaw.template.json
@@ -168,7 +168,7 @@
   "gateway": {
     "port": 18789,
     "mode": "local",
-    "bind": "loopback",
+    "bind": "lan",
     "auth": {
       "mode": "token",
       "token": "${OPENCLAW_GATEWAY_TOKEN}"


### PR DESCRIPTION
## Summary
- publish the OpenClaw gateway port on the Docker host instead of loopback only
- set the OpenClaw template gateway bind mode to lan
- update OpenClaw service docs to call out LAN exposure and token auth

## Testing
- jq . services/openclaw/config/openclaw.template.json >/dev/null
- docker compose -f services/openclaw/compose.yaml config --quiet

Assisted-by: GPT-5 via OpenClaw